### PR TITLE
Use env vars for Airflow DB connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,14 @@ services:
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      POSTGRES_DB: redfin
+      POSTGRES_DB: eziquio
     ports:
       - '5432:5432'
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./sql:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-postgres} -d $${POSTGRES_DB:-redfin}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-postgres} -d $${POSTGRES_DB:-eziquio}"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -23,7 +23,7 @@ services:
         condition: service_healthy
     environment:
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
-      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/redfin
+      AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: "postgresql+psycopg2://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/eziquio"
       AIRFLOW__CORE__FERNET_KEY: ''
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
     volumes:
@@ -41,7 +41,7 @@ services:
       POSTGRES_HOST: postgres
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      POSTGRES_DB: redfin
+      POSTGRES_DB: eziquio
       POSTGRES_PORT: 5432
     volumes:
       - ./redfin_dbt_project:/app

--- a/redfin_dbt_project/profiles.yml
+++ b/redfin_dbt_project/profiles.yml
@@ -7,6 +7,6 @@ redfin:
       user: {{ env_var('POSTGRES_USER', 'postgres') }}
       password: {{ env_var('POSTGRES_PASSWORD', 'postgres') }}
       port: {{ env_var('POSTGRES_PORT', '5432') }}
-      dbname: {{ env_var('POSTGRES_DB', 'redfin') }}
+      dbname: {{ env_var('POSTGRES_DB', 'eziquio') }}
       schema: public
       threads: 1

--- a/scripts/load_csv_to_postgres.py
+++ b/scripts/load_csv_to_postgres.py
@@ -7,7 +7,7 @@ import psycopg2
 # Get database credentials from environment variables
 DB_HOST = os.getenv('POSTGRES_HOST', 'localhost')
 DB_PORT = os.getenv('POSTGRES_PORT', '5432')
-DB_NAME = os.getenv('POSTGRES_DB', 'redfin')
+DB_NAME = os.getenv('POSTGRES_DB', 'eziquio')
 DB_USER = os.getenv('POSTGRES_USER', 'postgres')
 DB_PASSWORD = os.getenv('POSTGRES_PASSWORD', 'postgres')
 CSV_PATH = os.getenv('REDFIN_CSV_PATH', 'data/redfin_harvard_ma.csv')


### PR DESCRIPTION
## Summary
- keep Airflow DB connection string in sync with Postgres user env vars
- remove redundant `AIRFLOW__CORE__SQL_ALCHEMY_CONN`
- quote the connection string to avoid YAML parsing issues
- rename the Postgres database to `eziquio`

## Testing
- `pytest -q`