### PR TITLE
Ensure Airflow tasks use Postgres env vars

### DIFF
--- a/airflow/dags/redfin_pipeline_dag.py
+++ b/airflow/dags/redfin_pipeline_dag.py
@@ -25,6 +25,14 @@ dag = DAG(
 ingest_task = PythonOperator(
     task_id='ingest_csv',
     python_callable=load_csv,
+    op_kwargs={
+        'db_host': os.getenv('POSTGRES_HOST'),
+        'db_port': os.getenv('POSTGRES_PORT'),
+        'db_name': os.getenv('POSTGRES_DB'),
+        'db_user': os.getenv('POSTGRES_USER'),
+        'db_password': os.getenv('POSTGRES_PASSWORD'),
+        'csv_path': os.getenv('REDFIN_CSV_PATH'),
+    },
     dag=dag,
 )
 


### PR DESCRIPTION
## Summary
- pass Postgres connection env vars to `load_csv_to_postgres.py`
- allow `load_csv_to_postgres.py` to accept env vars at runtime

## Testing
- `python -m py_compile $(git ls-files '*.py')`